### PR TITLE
Fix blank counter text when starting widget configuration.

### DIFF
--- a/app/src/main/kotlin/com/brianco/simpledaycounter/DayCounterWidgetConfigureActivity.kt
+++ b/app/src/main/kotlin/com/brianco/simpledaycounter/DayCounterWidgetConfigureActivity.kt
@@ -17,9 +17,16 @@ import android.widget.LinearLayout
 import android.widget.TextView
 
 class DayCounterWidgetConfigureActivity : Activity() {
+  private val selectedHeaderColorSavedStateKey =
+    "${DayCounterWidgetConfigureActivity::class.qualifiedName}.selectedHeaderColor"
+  private val selectedBackgroundColorSavedStateKey =
+    "${DayCounterWidgetConfigureActivity::class.qualifiedName}.selectedBackgroundColor"
   private lateinit var widgetDataSaver: WidgetDataSaver
+  private lateinit var datePicker: DatePicker
   private lateinit var previewWidgetContainer: View
   private lateinit var previewLabel: TextView
+  private lateinit var previewCounter: TextView
+  private lateinit var previewDays: TextView
   private var selectedHeaderColor: Int = 0
   private var selectedBackgroundColor: Int = 0
 
@@ -38,11 +45,11 @@ class DayCounterWidgetConfigureActivity : Activity() {
     }
 
     setContentView(R.layout.activity_configuration)
-    val datePicker = findViewById<DatePicker>(R.id.configure_date_picker)
+    datePicker = findViewById(R.id.configure_date_picker)
     previewWidgetContainer = findViewById(R.id.widget_preview)
     previewLabel = previewWidgetContainer.findViewById(R.id.widget_label)
-    val previewCounter = previewWidgetContainer.findViewById<TextView>(R.id.widget_counter)
-    val previewDays = previewWidgetContainer.findViewById<TextView>(R.id.widget_days)
+    previewCounter = previewWidgetContainer.findViewById(R.id.widget_counter)
+    previewDays = previewWidgetContainer.findViewById(R.id.widget_days)
     val label = findViewById<EditText>(R.id.configure_label)
     val headerColorLinearLayoutView = findViewById<LinearLayout>(R.id.header_color_circle_container)
     val backgroundColorLinearLayoutView = findViewById<LinearLayout>(
@@ -50,13 +57,6 @@ class DayCounterWidgetConfigureActivity : Activity() {
     )
     val addWidgetButton = findViewById<Button>(R.id.configure_add)
 
-    label.addTextChangedListener(object : TextWatcher {
-      override fun beforeTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {}
-      override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {}
-      override fun afterTextChanged(editable: Editable) {
-        previewLabel.text = editable.toString()
-      }
-    })
     // val headerColors = listOf(
     //   R.color.header_1,
     //   R.color.header_2,
@@ -91,21 +91,37 @@ class DayCounterWidgetConfigureActivity : Activity() {
     }
 
     datePicker.setOnDateChangedListener { _, year, monthOfYear, dayOfMonth ->
-      val dayCount = dayCount(dateMidnightUtcMillis(dayOfMonth, monthOfYear, year))
-      previewCounter.text = getFormattedDayCount(resources, dayCount)
-      previewDays.text = getFormattedDays(resources, dayCount)
+      updateWidgetPreviewDayCounter(dayOfMonth, monthOfYear, year)
     }
 
-    if (widgetDataSaver.isWidget(appWidgetId)) {
+    label.addTextChangedListener(object : TextWatcher {
+      override fun beforeTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {}
+      override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {}
+      override fun afterTextChanged(editable: Editable) {
+        previewLabel.text = editable.toString()
+      }
+    })
+
+    if (savedInstanceState != null) {
+      // onRestoreInstanceState will set the previewCounter and previewDays texts after Android
+      // restores the DatePicker state.
+      // The label EditText's TextWatcher will set the previewLabel TextView text when Android
+      // restores the label EditText's text.
+      selectedHeaderColor = savedInstanceState.getInt(selectedHeaderColorSavedStateKey)
+      selectedBackgroundColor = savedInstanceState.getInt(selectedBackgroundColorSavedStateKey)
+    } else if (widgetDataSaver.isWidget(appWidgetId)) {
       dayMonthYear(widgetDataSaver.getDate(appWidgetId)) { dayOfMonth, month, year ->
         datePicker.updateDate(year, month, dayOfMonth)
       }
+      // The DatePicker change listener sets the previewCounter and previewDays texts.
       label.setText(widgetDataSaver.getLabel(appWidgetId))
+      // The label EditText's TextWatcher sets the previewLabel TextView text.
       selectedHeaderColor = widgetDataSaver.getHeaderColor(appWidgetId)
       selectedBackgroundColor = widgetDataSaver.getBackgroundColor(appWidgetId)
     } else {
       selectedHeaderColor = Color.parseColor(headerColors[0])
       selectedBackgroundColor = Color.parseColor(backgroundColors[0])
+      updateWidgetPreviewDayCounter()
     }
     updateWidgetPreviewColors(selectedHeaderColor, selectedBackgroundColor)
 
@@ -133,6 +149,17 @@ class DayCounterWidgetConfigureActivity : Activity() {
     previewWidgetContainer.setBackgroundColor(backgroundColor)
   }
 
+  private fun updateWidgetPreviewDayCounter() {
+    updateWidgetPreviewDayCounter(datePicker.dayOfMonth, datePicker.month, datePicker.year)
+  }
+
+  private fun updateWidgetPreviewDayCounter(dayOfMonth: Int, month: Int, year: Int) {
+    val dayCount = dayCount(dateMidnightUtcMillis(dayOfMonth, month, year))
+    val resources = resources
+    previewCounter.text = getFormattedDayCount(resources, dayCount)
+    previewDays.text = getFormattedDays(resources, dayCount)
+  }
+
   private fun addColorCircle(color: Int, layout: LinearLayout, isBackground: Boolean) {
     val layoutInflater = LayoutInflater.from(this)
     val colorView = layoutInflater.inflate(R.layout.color, layout, false)
@@ -148,5 +175,16 @@ class DayCounterWidgetConfigureActivity : Activity() {
       updateWidgetPreviewColors(selectedHeaderColor, selectedBackgroundColor)
     }
     layout.addView(colorView)
+  }
+
+  override fun onRestoreInstanceState(savedInstanceState: Bundle) {
+    super.onRestoreInstanceState(savedInstanceState)
+    updateWidgetPreviewDayCounter()
+  }
+
+  override fun onSaveInstanceState(outState: Bundle) {
+    super.onSaveInstanceState(outState)
+    outState.putInt(selectedHeaderColorSavedStateKey, selectedHeaderColor)
+    outState.putInt(selectedBackgroundColorSavedStateKey, selectedBackgroundColor)
   }
 }


### PR DESCRIPTION
And also restore state correctly (after low memory or a configuration change, for example).